### PR TITLE
Fixed bug caused by short container ids

### DIFF
--- a/spy.go
+++ b/spy.go
@@ -42,7 +42,8 @@ func (s *Spy) mutateContainerInCache(id string, status string) {
 
 	container, err := s.docker.InspectContainer(id)
 	if err != nil {
-		log.Printf("Unable to inspect container %s, skipping", id[:12])
+		log.Printf("Unable to inspect container %s, skipping", id)
+		// log.Printf("Unable to inspect container %s, skipping", id[:12])
 		return
 	}
 

--- a/spy.go
+++ b/spy.go
@@ -42,8 +42,7 @@ func (s *Spy) mutateContainerInCache(id string, status string) {
 
 	container, err := s.docker.InspectContainer(id)
 	if err != nil {
-		log.Printf("Unable to inspect container %s, skipping", id)
-		// log.Printf("Unable to inspect container %s, skipping", id[:12])
+		log.Printf("Unable to inspect container %s, skipping", TruncateString(id, 12))
 		return
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,10 @@
+package main
+
+func TruncateString(str string, maxLength int) string {
+  runes := []rune(str)
+  if len(runes) > maxLength {
+    return string(runes[:maxLength])
+  }
+
+  return str
+}


### PR DESCRIPTION
Not a Golang expert by any means, but seems like `str[:i]` results an exception if `str` length is smaller than `i`.

Anyways, figured that you're picking up up to 12 characters (might want to set this as a const?) from the container id, I've added a function which truncates the string correctly.
