### PR TITLE
TLS Support

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"fmt"
 
 	dockerApi "github.com/fsouza/go-dockerclient"
 )
@@ -15,6 +16,7 @@ var dnsPort = flag.String("dns-port", getopt("DNS_PORT", "53"), "Port for the DN
 var dnsRecursor = flag.String("dns-recursor", getopt("DNS_RECURSOR", ""), "DNS recursor for non-local addresses")
 var dnsDomain = flag.String("dns-domain", getopt("DNS_DOMAIN", "localdomain"), "The domain that Docker-spy should consider local")
 var dockerHost = flag.String("docker-host", getopt("DOCKER_HOST", "unix:///var/run/docker.sock"), "Address for the Docker daemon")
+var dockerCertPath = flag.String("docker-cert-path", getopt("DOCKER_CERT_PATH", ""), "Location of certificates for TLS")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -45,7 +47,16 @@ func main() {
 
 	log.Println("Listening for container events...")
 
-	docker, err := dockerApi.NewClient(*dockerHost)
+	var docker *dockerApi.Client
+	
+	if *dockerCertPath == "" {
+		docker, err = dockerApi.NewClient(*dockerHost)		
+	} else {
+		ca := fmt.Sprintf("%s/ca.pem", *dockerCertPath)
+    	cert := fmt.Sprintf("%s/cert.pem", *dockerCertPath)
+    	key := fmt.Sprintf("%s/key.pem", *dockerCertPath)
+    	docker, err = dockerApi.NewTLSClient(*dockerHost, cert, key, ca)
+	}
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
As per the instructions at https://github.com/fsouza/go-dockerclient, this enables TLS support when the docker daemon is using secured TCP communication.
