### PR TITLE
Fix domain name handling

### DIFF
--- a/spy.go
+++ b/spy.go
@@ -46,7 +46,10 @@ func (s *Spy) mutateContainerInCache(id string, status string) {
 		return
 	}
 
-	name := container.Config.Hostname + "." + container.Config.Domainname + "."
+	name := container.Config.Hostname + "."
+	if len(container.Config.Domainname) > 0 {
+		name += container.Config.Domainname + "."
+	}
 
 	var running = regexp.MustCompile("start|^Up.*$")
 	var stopping = regexp.MustCompile("die")


### PR DESCRIPTION
Newer versions of Docker does not split the given hostname by the dot character,
but it places the whole hostname string to the Config.Hostname setting, leaving
Config.Domainname empty.
This commit makes sure that a valid FQDN is put together regardless of Docker config.
